### PR TITLE
bugfix/make-adaptive-sm-octopus-title

### DIFF
--- a/src/scss/_octopus.scss
+++ b/src/scss/_octopus.scss
@@ -155,14 +155,12 @@
       margin-top: 5px;
     }
 
-    @media screen and (max-width: $lg) {
-      width: 700px;
-    }
-
     @media screen and (max-width: $sm) {
-      width: 535px;
-
       margin-top: 10px;
+
+      text-align: center;
+
+      padding: 10px;
     }
 
     @media screen and (max-width: $xs) {


### PR DESCRIPTION
Removed width dimensions in media-lg, media-sm, now the header does not fall out of the container.

![q1](https://user-images.githubusercontent.com/62384781/200122622-931aa583-5f61-4693-85fb-164cb690d306.png)
