### PR TITLE
bugfix/make-adaptive-sm-octopus-img

### DIFF
--- a/src/scss/_octopus.scss
+++ b/src/scss/_octopus.scss
@@ -118,7 +118,7 @@
     }
 
     @media screen and (max-width: $sm) {
-      width: 410px;
+      width: 360px;
     }
 
     @media screen and (max-width: $xs) {


### PR DESCRIPTION
Change the size of octopus__img, now the picture does not fall out of the container.

![q2](https://user-images.githubusercontent.com/62384781/200122511-959ddbb8-9b9e-4835-829e-1134f08e8b52.png)
