### PR TITLE
bugfix/make-adaptive-sm-octopus-background-imgs

### DIFF
--- a/src/scss/_octopus.scss
+++ b/src/scss/_octopus.scss
@@ -46,7 +46,7 @@
     background-image: url('../images/bubble.png'), url('../images/Group_bubls.png'),
       linear-gradient(252.43deg, #d45b78 0.01%, #4b3862 101.01%);
     background-repeat: no-repeat, no-repeat, no-repeat;
-    background-position: left 25px bottom 35px, right 10px bottom 30px, top 0 left 0;
+    background-position: left -2px bottom 23px,right 0px bottom 30px,top 0 left 0;
     background-size: 80px 135px, 65px 100px, 100%;
     min-height: auto;
   }


### PR DESCRIPTION
Changed the pictures of the background, put them flatter, in accordance with the changes in the other blocks.

![q3](https://user-images.githubusercontent.com/62384781/200122960-b67a282c-5a99-4822-9a1e-50cc69670eaf.png)
