### PR TITLE
bugfix/make-adaptive-sm-header-logo

### DIFF
--- a/src/scss/_header.scss
+++ b/src/scss/_header.scss
@@ -29,6 +29,11 @@
       height: 69px;
     }
 
+    @media screen and (max-width: $sm) {
+      width: 60px;
+      height: 62px;
+    }
+
     @media screen and (max-width: $xs) {
       width: 50px;
       height: 49px;


### PR DESCRIPTION
Changed the size of the header-logo so that it is not so big.

![q8](https://user-images.githubusercontent.com/62384781/200126613-74036bbd-a014-49c0-93cc-cad7b243a80f.png)
