### PR TITLE
bugfix/make-adaptive-sm-header-btns

### DIFF
--- a/src/scss/_header.scss
+++ b/src/scss/_header.scss
@@ -35,6 +35,12 @@
     }
   }
 
+  &__button {
+    @media screen and (max-width: $sm) {
+      font-size: $font__size-16;
+    }
+  }
+
   &__btns {
     @media screen and (max-width: $xs) {
       display: none;

--- a/src/scss/_styles.scss
+++ b/src/scss/_styles.scss
@@ -199,6 +199,10 @@ button {
   @media screen and (max-width: $lg) {
     font-size: $font__size-14;
   }
+
+  @media screen and (max-width: $sm) {
+    padding: 3px 20px;
+  }
 }
 
 .button__outlined-md {


### PR DESCRIPTION
Changed the font-size of the buttons, made them smaller to match the size of the logo, and their internal indentation. In the screenshot they are together with the logo, so you can see the ratio.


![q7](https://user-images.githubusercontent.com/62384781/200126538-b533901e-363d-42d8-9d2b-5ce1d3077ffb.png)
