### PR TITLE
bugfix/make-adaptive-md-octopus-title

### DIFF
--- a/src/scss/_octopus.scss
+++ b/src/scss/_octopus.scss
@@ -155,8 +155,8 @@
       margin-top: 5px;
     }
 
-    @media screen and (max-width: $lg) {
-      width: 700px;
+    @media screen and (max-width: $md) {
+      text-align: center;
     }
 
     @media screen and (max-width: $sm) {


### PR DESCRIPTION
Made the text centered, there at 601px one word goes down on another line, but further down in size it becomes 2 lines. Removed the text width, thought it would be better for the adaptive version.

![q10](https://user-images.githubusercontent.com/62384781/200134720-3a64ef00-4e42-4b2f-93c5-3f1780cd6544.png)
