### PR TITLE
bugfix/make-adaptive-md-octopus-background-imgs

### DIFF
--- a/src/scss/_octopus.scss
+++ b/src/scss/_octopus.scss
@@ -36,7 +36,7 @@
     background-image: url('../images/bubble.png'), url('../images/Group_bubls.png'),
       linear-gradient(252.43deg, #d45b78 0.01%, #4b3862 101.01%);
     background-repeat: no-repeat, no-repeat, no-repeat;
-    background-position: left 50px bottom 50px, right 20px bottom 75px, top 0 left 0;
+    background-position: left 10px bottom 40px,right 20px bottom 30px,top 0 left 0;
     background-size: 100px 165px, 85px 125px, 100%;
     min-height: auto;
   }


### PR DESCRIPTION
Moved background-images.

![q12](https://user-images.githubusercontent.com/62384781/200134986-67577220-5bd8-43b6-bcbd-681e451ab692.png)
